### PR TITLE
Change massive integers to use diagnostic tests

### DIFF
--- a/appendix_a.json
+++ b/appendix_a.json
@@ -63,25 +63,25 @@
     "cbor": "G///////////",
     "hex": "1bffffffffffffffff",
     "roundtrip": true,
-    "decoded": 18446744073709551615
+    "diagnostic": "18446744073709551615"
   },
   {
     "cbor": "wkkBAAAAAAAAAAA=",
     "hex": "c249010000000000000000",
     "roundtrip": true,
-    "decoded": 18446744073709551616
+    "diagnostic": "18446744073709551616"
   },
   {
     "cbor": "O///////////",
     "hex": "3bffffffffffffffff",
     "roundtrip": true,
-    "decoded": -18446744073709551616
+    "diagnostic": "-18446744073709551616"
   },
   {
     "cbor": "w0kBAAAAAAAAAAA=",
     "hex": "c349010000000000000000",
     "roundtrip": true,
-    "decoded": -18446744073709551617
+    "diagnostic": "-18446744073709551617"
   },
   {
     "cbor": "IA==",


### PR DESCRIPTION
This helps with JSON parsers that throw exceptions on integers that blow out a 64-bit signed integer, such as the one in the Nim standard library.

This addresses the problems mentioned in #2.